### PR TITLE
chore: allow `1.0.0` in version constraint for `http`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: unsplash_client
-description:
-  Unsplash provides free high-resolution photos. This is a client for their REST
+description: Unsplash provides free high-resolution photos. This is a client for their REST
   API.
 version: 2.1.0+3
 repository: https://github.com/blaugold/unsplash_client
@@ -12,7 +11,7 @@ environment:
 
 dependencies:
   meta: ^1.2.4
-  http: ^0.13.0
+  http: '>=0.13.0 <2.0.0'
   collection: ^1.14.13
   logging: ^1.0.1
 


### PR DESCRIPTION
Many packages are requiring `http 1.0.0`, and this will make it easier to this package to work with those.