### PR TITLE
Dynamic proxy url

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ final client = UnsplashClient(
 > :warning: When you are done using a client instance, make sure to call it's
 > `close` method.
 
+### Moving authentication to an authentication proxy
+
+If you would like to use an authentication proxy and want to change the URL of the 
+Unsplash API endpoint you can use the following code:
+
+```dart
+final client = UnsplashClient(
+  settings: const ClientSettings()),
+  proxyBaseUrl: Uri.parse('YOUR_PROXY_URL'));
+);
+```
+You can omit the `credentials` parameter and provide your own endpoint by 
+using the `proxyBaseUrl` parameter.
+
 ## Get a random photo
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ final client = UnsplashClient(
 > :warning: When you are done using a client instance, make sure to call it's
 > `close` method.
 
-### Moving authentication to an authentication proxy
+### Moving Unsplash authentication to an authentication proxy
 
 If you would like to use an authentication proxy and want to change the URL of the 
-Unsplash API endpoint you can use the following code:
+Unsplash API endpoint to your proxy URL you can use the following code:
 
 ```dart
 final client = UnsplashClient(
@@ -63,6 +63,18 @@ final client = UnsplashClient(
 ```
 You can omit the `credentials` parameter and provide your own endpoint by 
 using the `proxyBaseUrl` parameter.
+
+If your authentication proxy requires authentication as well you can authenticate using a `bearer token` like so:
+```dart
+final client = UnsplashClient(
+  settings: const ClientSettings(bearerToken: 'YOUR_BEARER_TOKEN')),
+  proxyBaseUrl: Uri.parse('YOUR_PROXY_URL'));
+);
+```
+The bearer token will be assembled to a HTTP header like so:
+```
+Authorization: Bearer YOUR_BEARER_TOKEN
+```
 
 ## Get a random photo
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ void main(List<String> args) async {
 
   // Create a client.
   final client = UnsplashClient(
-    settings: ClientSettings(credentials: appCredentials),
+    settings: ClientSettings(unsplashCredentials: appCredentials),
   );
 
   // Fetch 5 random photos by calling `goAndGet` to execute the [Request]

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -18,7 +18,7 @@ import 'users.dart';
 class ClientSettings {
   /// Creates new [ClientSettings].
   ///
-  /// [credentials] must not be `null`.
+  /// [credentials] must not be `null` if using no proxy URL.
   const ClientSettings({
     this.credentials,
     this.debug = false,
@@ -26,6 +26,7 @@ class ClientSettings {
   });
 
   /// The credentials used by the [UnsplashClient] to authenticate the app.
+  /// These can be null in case a proxy for authentication is being used
   final AppCredentials? credentials;
 
   /// Whether to log debug information.

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -2,8 +2,7 @@ import 'package:test/test.dart';
 import 'package:unsplash_client/unsplash_client.dart';
 
 void main() {
-  test('executing requests after client has been closed should throw',
-      () async {
+  test('executing requests after client has been closed should throw', () async {
     final client = UnsplashClient(
       settings: ClientSettings(
         credentials: AppCredentials(
@@ -18,5 +17,46 @@ void main() {
     final req = client.users.get('username');
 
     expect(req.go, throwsStateError);
+  });
+
+  test('standard client functions work without app credentials as expected', () {
+    final clientWithSettings = UnsplashClient(
+      settings: const ClientSettings(
+        credentials: AppCredentials(
+          secretKey: '1234',
+          accessKey: '5678',
+        ),
+      ),
+    );
+
+    final clientWithoutSettings = UnsplashClient(
+      settings: const ClientSettings(),
+    );
+
+    expect(clientWithSettings.settings == clientWithSettings.settings, true);
+    expect(clientWithSettings.settings == clientWithoutSettings.settings, false);
+    expect(clientWithoutSettings.settings == clientWithSettings.settings, false);
+    expect(clientWithoutSettings.settings == clientWithoutSettings.settings, true);
+
+    var clientWithSettingsHashCode = clientWithSettings.settings.hashCode;
+    expect(clientWithSettingsHashCode == 1043090474, true);
+
+    var clientWithoutSettingsHashCode = clientWithoutSettings.settings.hashCode;
+    expect(clientWithoutSettingsHashCode == 346277, true);
+
+    var clientWithSettingsString = clientWithSettings.settings.toString();
+    expect(
+        clientWithSettingsString ==
+            'ClientSettings{credentials: Credentials{accessKey: 5678, '
+                'secretKey: HIDDEN}, '
+                'maxPageSize: 30}',
+        true);
+
+    var clientWithoutSettingsString = clientWithoutSettings.settings.toString();
+    expect(
+        clientWithoutSettingsString ==
+            'ClientSettings{credentials: null, '
+                'maxPageSize: 30}',
+        true);
   });
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('executing requests after client has been closed should throw', () async {
     final client = UnsplashClient(
       settings: ClientSettings(
-        credentials: AppCredentials(
+        unsplashCredentials: AppCredentials(
           secretKey: '',
           accessKey: '',
         ),
@@ -20,42 +20,44 @@ void main() {
   });
 
   test('standard client functions work without app credentials as expected', () {
-    final clientWithSettings = UnsplashClient(
+    final clientWithUnsplashCredentials = UnsplashClient(
       settings: const ClientSettings(
-        credentials: AppCredentials(
+        unsplashCredentials: AppCredentials(
           secretKey: '1234',
           accessKey: '5678',
         ),
       ),
     );
 
-    final clientWithoutSettings = UnsplashClient(
-      settings: const ClientSettings(),
+    final clientWithoutUnsplashCredentials = UnsplashClient(
+      settings: const ClientSettings(bearerToken: '1234'),
     );
 
-    expect(clientWithSettings.settings == clientWithSettings.settings, true);
-    expect(clientWithSettings.settings == clientWithoutSettings.settings, false);
-    expect(clientWithoutSettings.settings == clientWithSettings.settings, false);
-    expect(clientWithoutSettings.settings == clientWithoutSettings.settings, true);
+    expect(clientWithUnsplashCredentials.settings == clientWithUnsplashCredentials.settings, true);
+    expect(clientWithUnsplashCredentials.settings == clientWithoutUnsplashCredentials.settings, false);
+    expect(clientWithoutUnsplashCredentials.settings == clientWithUnsplashCredentials.settings, false);
+    expect(clientWithoutUnsplashCredentials.settings == clientWithoutUnsplashCredentials.settings, true);
 
-    var clientWithSettingsHashCode = clientWithSettings.settings.hashCode;
-    expect(clientWithSettingsHashCode == 1043090474, true);
+    var clientWithSettingsHashCode = clientWithUnsplashCredentials.settings.hashCode;
+    expect(clientWithSettingsHashCode == 1043090417, true);
 
-    var clientWithoutSettingsHashCode = clientWithoutSettings.settings.hashCode;
-    expect(clientWithoutSettingsHashCode == 346277, true);
+    var clientWithoutUnsplashCredentialsHashCode = clientWithoutUnsplashCredentials.settings.hashCode;
+    expect(clientWithoutUnsplashCredentialsHashCode == 759431771, true);
 
-    var clientWithSettingsString = clientWithSettings.settings.toString();
+    var clientWithUnsplashCredentialsString = clientWithUnsplashCredentials.settings.toString();
     expect(
-        clientWithSettingsString ==
+        clientWithUnsplashCredentialsString ==
             'ClientSettings{credentials: Credentials{accessKey: 5678, '
                 'secretKey: HIDDEN}, '
+                'bearerToken: null, '
                 'maxPageSize: 30}',
         true);
 
-    var clientWithoutSettingsString = clientWithoutSettings.settings.toString();
+    var clientWithoutUnsplashCredentialsString = clientWithoutUnsplashCredentials.settings.toString();
     expect(
-        clientWithoutSettingsString ==
+        clientWithoutUnsplashCredentialsString ==
             'ClientSettings{credentials: null, '
+                'bearerToken: 1234, '
                 'maxPageSize: 30}',
         true);
   });

--- a/test/collections_test.dart
+++ b/test/collections_test.dart
@@ -6,7 +6,7 @@ import 'test_utils.dart';
 void main() {
   final client = UnsplashClient(
     settings: ClientSettings(
-      credentials: AppCredentials(
+      unsplashCredentials: AppCredentials(
         secretKey: '',
         accessKey: '',
       ),

--- a/test/integration/integration_test_utils.dart
+++ b/test/integration/integration_test_utils.dart
@@ -15,8 +15,7 @@ void setupIntegrationTests(String name) {
   }
   _hasSetupIntegrationTests = true;
 
-  _recordedExpectations =
-      File.fromUri(_recordedExpectationsDir.uri.resolve('$name.json'));
+  _recordedExpectations = File.fromUri(_recordedExpectationsDir.uri.resolve('$name.json'));
 
   _setupRecordedExpectationsTestHooks();
   _setupTestClientTestHooks();
@@ -26,11 +25,9 @@ bool get isCI => Platform.environment['CI'] != null;
 
 // === Recorded Expectations ===================================================
 
-bool get _updateRecordedExpectations =>
-    Platform.environment['UPDATE_RECORDED_EXPECTATIONS'] != null;
+bool get _updateRecordedExpectations => Platform.environment['UPDATE_RECORDED_EXPECTATIONS'] != null;
 
-final _recordedExpectationsDir =
-    Directory('test/fixtures/recorded_expectations');
+final _recordedExpectationsDir = Directory('test/fixtures/recorded_expectations');
 late File _recordedExpectations;
 
 late MockServer mockServer;
@@ -49,8 +46,7 @@ void _setupRecordedExpectationsTestHooks() {
         'There are no recorded expectations.',
       );
 
-      final recordedExpectations =
-          decodeExpectations(await _recordedExpectations.readAsString());
+      final recordedExpectations = decodeExpectations(await _recordedExpectations.readAsString());
 
       // If the content of `User-Agent` changes we can still use the recorded
       // expectations, since the header does not change the expected response.
@@ -87,8 +83,7 @@ void _setupRecordedExpectationsTestHooks() {
 
       await _recordedExpectations.parent.create(recursive: true);
       final jsonEncoder = const JsonEncoder.withIndent('  ');
-      await _recordedExpectations
-          .writeAsString(jsonEncoder.convert(recordedExpectations));
+      await _recordedExpectations.writeAsString(jsonEncoder.convert(recordedExpectations));
     }
 
     mockServer.close();
@@ -141,12 +136,10 @@ void _setupTestClientTestHooks() {
   setUpAll(() async {
     // In CI we run tests always against recorded responses and need not
     // credentials.
-    final credentials = isCI
-        ? AppCredentials(accessKey: '', secretKey: '')
-        : await getTestAppCredentials();
+    final credentials = isCI ? AppCredentials(accessKey: '', secretKey: '') : await getTestAppCredentials();
 
     client = UnsplashClient(
-      settings: ClientSettings(credentials: credentials),
+      settings: ClientSettings(unsplashCredentials: credentials),
       httpClient: IOClient(mockServer.createProxiedHttpClient()),
     );
   });

--- a/test/photos_test.dart
+++ b/test/photos_test.dart
@@ -6,7 +6,7 @@ import 'test_utils.dart';
 void main() {
   final client = UnsplashClient(
     settings: ClientSettings(
-      credentials: AppCredentials(
+      unsplashCredentials: AppCredentials(
         secretKey: '',
         accessKey: '',
       ),

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -6,7 +6,7 @@ import 'test_utils.dart';
 void main() {
   final client = UnsplashClient(
     settings: ClientSettings(
-      credentials: AppCredentials(
+      unsplashCredentials: AppCredentials(
         secretKey: '',
         accessKey: '',
       ),

--- a/test/stats_test.dart
+++ b/test/stats_test.dart
@@ -6,7 +6,7 @@ import 'test_utils.dart';
 void main() {
   final client = UnsplashClient(
     settings: ClientSettings(
-      credentials: AppCredentials(
+      unsplashCredentials: AppCredentials(
         secretKey: '',
         accessKey: '',
       ),

--- a/test/topics_test.dart
+++ b/test/topics_test.dart
@@ -6,7 +6,7 @@ import 'test_utils.dart';
 void main() {
   final client = UnsplashClient(
     settings: ClientSettings(
-      credentials: AppCredentials(
+      unsplashCredentials: AppCredentials(
         secretKey: '',
         accessKey: '',
       ),

--- a/test/users_test.dart
+++ b/test/users_test.dart
@@ -6,7 +6,7 @@ import 'test_utils.dart';
 void main() {
   final client = UnsplashClient(
     settings: ClientSettings(
-      credentials: AppCredentials(
+      unsplashCredentials: AppCredentials(
         secretKey: '',
         accessKey: '',
       ),


### PR DESCRIPTION
Hi Blaugold,
I am using your client library for my Flutter app and since Unsplash does not allow storing the secret and access key on the user devices I built a small cloud authentication proxy.
Your client library currently does not allow to change the URL and omit the credentials parameter. I did some minor changes to 

1. make the URL a parameter (proxyBaseUrl) but keep the default Unsplash URL in case no URL is provided,
2. make the unsplashCredentials parameter of the Settings class optional including a null check when adding the credentials to the HTTP header,
4. introduced a bearerToken parameter for situations when the proxy requires authentication as well,
5. introduced a new test case to make sure that a missing credentials parameter is not breaking any of the functionality,
6. updated the readme accordingly.

I am new to Dart programming so let me know if there are things I could improve in the code.
Best regards
Oliver